### PR TITLE
Teacher Profile 의 Career 저장 관련 문제 해결

### DIFF
--- a/src/main/java/promiseofblood/umpabackend/application/service/Oauth2Service.java
+++ b/src/main/java/promiseofblood/umpabackend/application/service/Oauth2Service.java
@@ -93,7 +93,7 @@ public class Oauth2Service {
     return oauth2Strategy.getOauth2UserProfile(oauth2Provider, code);
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   public LoginCompleteResponse generateOauth2Jwt(
     String providerName, String externalIdToken, String externalAccessToken) {
 

--- a/src/main/java/promiseofblood/umpabackend/application/service/Oauth2Service.java
+++ b/src/main/java/promiseofblood/umpabackend/application/service/Oauth2Service.java
@@ -93,6 +93,7 @@ public class Oauth2Service {
     return oauth2Strategy.getOauth2UserProfile(oauth2Provider, code);
   }
 
+  @Transactional
   public LoginCompleteResponse generateOauth2Jwt(
     String providerName, String externalIdToken, String externalAccessToken) {
 

--- a/src/main/java/promiseofblood/umpabackend/domain/entity/TeacherCareer.java
+++ b/src/main/java/promiseofblood/umpabackend/domain/entity/TeacherCareer.java
@@ -1,11 +1,15 @@
 package promiseofblood.umpabackend.domain.entity;
 
+import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Converter;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,9 +32,11 @@ public class TeacherCareer extends TimeStampedEntity {
 
   private String title;
 
+  @Convert(converter = YearMonthConverter.class)
   private YearMonth start;
 
   @Column(name = "\"end\"")
+  @Convert(converter = YearMonthConverter.class)
   private YearMonth end;
 
   @ManyToOne
@@ -45,5 +51,21 @@ public class TeacherCareer extends TimeStampedEntity {
       .start(request.getStart())
       .end(request.getEnd())
       .build();
+  }
+
+  @Converter(autoApply = true)
+  static class YearMonthConverter implements AttributeConverter<YearMonth, String> {
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
+
+    @Override
+    public String convertToDatabaseColumn(YearMonth yearMonth) {
+      return yearMonth.format(formatter);
+    }
+
+    @Override
+    public YearMonth convertToEntityAttribute(String dbData) {
+      return YearMonth.parse(dbData, formatter);
+    }
   }
 }


### PR DESCRIPTION
## 주요 변경 사항
- `TeacherCareer` Entity 의 `start`, `end` 멤버에 대한 DB 스키마 불일치 해결
- https://github.com/Promise-of-Blood/umpa-backend/blob/b90c2970757a1e964da705b758a9e4b749347185/src/main/java/promiseofblood/umpabackend/application/service/Oauth2Service.java#L111-L113
위 112 라인에서 DTO 를 생성할 때, Lazy fetch 를 하게 되는데 트랜젝션으로 묶여있지 않아서 예외가 발생했었음. -> 트랜젝션으로 묶어서 해결(`open-in-view: false` 설정으로 인해 발생한 이슈)

## 기타
- 예상 리뷰 시간: 3~5분

DB 스키마 불일치 해결로 인해 서비스 목록 API 도 정상 작동하게 되니, 해당 변경사항이 승인된다면 빠르게 main에 병합했으면 하는 바람!


