### PR TITLE
서비스 목록 요청 API의 Query Parameter 유효성 검사 추가

### DIFF
--- a/src/main/java/promiseofblood/umpabackend/web/advice/GlobalExceptionHandler.java
+++ b/src/main/java/promiseofblood/umpabackend/web/advice/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package promiseofblood.umpabackend.web.advice;
 
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
+import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import promiseofblood.umpabackend.application.exception.NotFoundException;
 import promiseofblood.umpabackend.application.exception.NotSupportedOauth2ProviderException;
 import promiseofblood.umpabackend.application.exception.Oauth2UserAlreadyExists;
@@ -107,6 +109,23 @@ public class GlobalExceptionHandler {
       new ApiResponse.ExceptionResponse("유효성 검사 실패: " + builder);
 
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
+  }
+
+  @ExceptionHandler(HandlerMethodValidationException.class)
+  public ResponseEntity<ApiResponse.ExceptionResponse> handleHandlerMethodValidationException(
+    HandlerMethodValidationException ex, WebRequest request) {
+
+    log.error(ex.getMessage(), ex);
+
+    String message = Arrays.stream(ex.getDetailMessageArguments())
+      .findFirst()
+      .orElse("유효성 검사 실패")
+      .toString();
+
+    ApiResponse.ExceptionResponse exceptionResponse =
+      new ApiResponse.ExceptionResponse(message);
+
+    return ResponseEntity.status(ex.getStatusCode()).body(exceptionResponse);
   }
 
   // 404

--- a/src/main/java/promiseofblood/umpabackend/web/controller/MrProductionServiceController.java
+++ b/src/main/java/promiseofblood/umpabackend/web/controller/MrProductionServiceController.java
@@ -3,6 +3,7 @@ package promiseofblood.umpabackend.web.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
@@ -40,7 +41,8 @@ public class MrProductionServiceController {
   @GetMapping(path = "/mr-production")
   public ResponseEntity<PaginatedResponse<ServicePostResponse>>
   getAllMrProductionServices(
-    @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+    @RequestParam(defaultValue = "0") int page,
+    @RequestParam(defaultValue = "10") @Min(value = 1, message = "size는 0보다 커야 합니다.") int size) {
 
     Page<ServicePostResponse> servicePostResponsePage =
       this.serviceBoardService.getAllServices("MR_PRODUCTION", page, size);


### PR DESCRIPTION
## 주요 변경 사항
- @Min 유효성 검사 추가
- @Min 유효성 검사 실패 시 발생하는 `HandlerMethodValidationException` 핸들링 추가

## 예상 기대 효과
- 500응답 대신 클라이언트에게 올바른 응답 반환
- 추후 비슷한 유효성 검사 필요 시 즉시 활용할 수 있음

## 기타
- 예상 리뷰 시간: 2~3분