### PR TITLE
선생님 프로필에 대표문구(keyphrase) 항목 추가 

### DIFF
--- a/src/main/java/promiseofblood/umpabackend/domain/entity/TeacherProfile.java
+++ b/src/main/java/promiseofblood/umpabackend/domain/entity/TeacherProfile.java
@@ -24,6 +24,8 @@ import promiseofblood.umpabackend.dto.TeacherProfileDto;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeacherProfile extends TimeStampedEntity {
 
+  private String keyphrase;
+
   private String description;
 
   @Enumerated(EnumType.STRING)
@@ -38,6 +40,7 @@ public class TeacherProfile extends TimeStampedEntity {
   public static TeacherProfile from(TeacherProfileDto.TeacherProfileRequest request) {
 
     return TeacherProfile.builder()
+      .keyphrase(request.getKeyphrase())
       .description(request.getDescription())
       .major(request.getMajor())
       .careers(request.getCareers().stream().map(TeacherCareer::from).toList())
@@ -52,6 +55,9 @@ public class TeacherProfile extends TimeStampedEntity {
   }
 
   public void update(TeacherProfileDto.TeacherProfileRequest request) {
+    if (request.getKeyphrase() != null) {
+      this.keyphrase = request.getKeyphrase();
+    }
     if (request.getDescription() != null) {
       this.description = request.getDescription();
     }

--- a/src/main/java/promiseofblood/umpabackend/dto/ServicePostDto.java
+++ b/src/main/java/promiseofblood/umpabackend/dto/ServicePostDto.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import promiseofblood.umpabackend.domain.entity.TeacherProfile;
 import promiseofblood.umpabackend.domain.vo.DurationRange;
 import promiseofblood.umpabackend.domain.vo.ServiceCost;
 import promiseofblood.umpabackend.domain.entity.TeacherCareer;
@@ -20,6 +21,8 @@ public class ServicePostDto {
   @Builder(access = AccessLevel.PRIVATE)
   public static class TeacherAuthorProfileDto {
 
+    private String keyphrase;
+
     private String profileImageUrl;
 
     private String description;
@@ -30,19 +33,22 @@ public class ServicePostDto {
 
     public static TeacherAuthorProfileDto from(User user) {
 
+      TeacherProfile teacherProfile = user.getTeacherProfile();
+
       List<TeacherProfileDto.TeacherCareerDto> careers = new ArrayList<>();
-      for (TeacherCareer career : user.getTeacherProfile().getCareers()) {
+      for (TeacherCareer career : teacherProfile.getCareers()) {
         careers.add(TeacherCareerDto.from(career));
       }
 
       List<TeacherProfileDto.TeacherLinkDto> links = new ArrayList<>();
-      for (TeacherLink link : user.getTeacherProfile().getLinks()) {
+      for (TeacherLink link : teacherProfile.getLinks()) {
         links.add(TeacherProfileDto.TeacherLinkDto.from(link));
       }
 
       return TeacherAuthorProfileDto.builder()
+          .keyphrase(teacherProfile.getKeyphrase())
           .profileImageUrl(user.getProfileImageUrl())
-          .description(user.getTeacherProfile().getDescription())
+          .description(teacherProfile.getDescription())
           .careers(careers)
           .links(links)
           .build();

--- a/src/main/java/promiseofblood/umpabackend/dto/TeacherProfileDto.java
+++ b/src/main/java/promiseofblood/umpabackend/dto/TeacherProfileDto.java
@@ -24,6 +24,9 @@ public class TeacherProfileDto {
   @AllArgsConstructor
   public static class TeacherProfileRequest {
 
+    @Schema(description = "대표 문구", example = "멋쟁이 토마토")
+    private String keyphrase;
+
     @Schema(
         description = "선생님 소개",
         example = "안녕하세요, 저는 전자 음악을 전공한 선생님입니다. 레슨을 통해 여러분과 함께 음악의 즐거움을 나누고 싶습니다.")
@@ -68,6 +71,8 @@ public class TeacherProfileDto {
   @ToString
   public static class TeacherProfileResponse {
 
+    private String keyphrase;
+
     private String description;
 
     private ConstantDto.MajorResponse major;
@@ -89,6 +94,7 @@ public class TeacherProfileDto {
       }
 
       return TeacherProfileResponse.builder()
+          .keyphrase(teacherProfile.getKeyphrase())
           .description(teacherProfile.getDescription())
           .major(ConstantDto.MajorResponse.from(teacherProfile.getMajor()))
           .careers(teacherCareerDtoList)

--- a/src/test/java/promiseofblood/umpabackend/application/service/ProfileServiceTest.java
+++ b/src/test/java/promiseofblood/umpabackend/application/service/ProfileServiceTest.java
@@ -1,107 +1,135 @@
-//package promiseofblood.umpabackend.application.service;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertThrows;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.when;
-//
-//import jakarta.validation.ConstraintViolation;
-//import jakarta.validation.Validation;
-//import jakarta.validation.Validator;
-//import jakarta.validation.ValidatorFactory;
-//import java.util.Optional;
-//import java.util.Set;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import promiseofblood.umpabackend.domain.entity.User;
-//import promiseofblood.umpabackend.domain.repository.UserRepository;
-//import promiseofblood.umpabackend.domain.vo.Gender;
-//import promiseofblood.umpabackend.domain.vo.ProfileType;
-//import promiseofblood.umpabackend.dto.UserDto.DefaultProfilePatchRequest;
-//
-//@ExtendWith(MockitoExtension.class)
-//class ProfileServiceTest {
-//
-//  @Mock
-//  private UserRepository userRepository;
-//
-//  @Mock
-//  private StorageService storageService;
-//
-//  @InjectMocks
-//  private ProfileService subject;
-//
-//  private Validator validator;
-//
-//  @BeforeEach
-//  void setUp() {
-//    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-//    validator = factory.getValidator();
-//  }
-//
-//  @Test
-//  @DisplayName("사용자 닉네임이 8자를 초과하면 검증 오류가 발생해야 한다")
-//  void validateUsername_whenExceedsMaxLength_shouldFailValidation() {
-//    // Given
-//    DefaultProfilePatchRequest requestWithLongUsername = new DefaultProfilePatchRequest(
-//      "닉네임이너무길어요", // 8자 초과 닉네임
-//      Gender.MALE,
-//      ProfileType.STUDENT,
-//      null
-//    );
-//
-//    // When
-//    Set<ConstraintViolation<DefaultProfilePatchRequest>> violations = validator.validate(
-//      requestWithLongUsername);
-//
-//    // Then
-//    assertEquals(1, violations.size());
-//    assertEquals("사용자 닉네임은 최대 8자까지 가능합니다.", violations.iterator().next().getMessage());
-//  }
-//
-//  @Test
-//  @DisplayName("사용자 닉네임이 8자 이하면 검증에 성공해야 한다")
-//  void validateUsername_whenWithinMaxLength_shouldPassValidation() {
-//    // Given
-//    DefaultProfilePatchRequest requestWithValidUsername = new DefaultProfilePatchRequest(
-//      "홍길동", // 8자 이하 닉네임
-//      Gender.MALE,
-//      ProfileType.STUDENT,
-//      null
-//    );
-//
-//    // When
-//    Set<ConstraintViolation<DefaultProfilePatchRequest>> violations = validator.validate(
-//      requestWithValidUsername);
-//
-//    // Then
-//    assertEquals(0, violations.size());
-//  }
-//
-//  @Test
-//  @DisplayName("정확히 8자의 닉네임은 검증에 성공해야 한다")
-//  void validateUsername_whenExactlyMaxLength_shouldPassValidation() {
-//    // Given
-//    DefaultProfilePatchRequest requestWithBorderlineUsername = new DefaultProfilePatchRequest(
-//      "12345678", // 정확히 8자 닉네임
-//      Gender.MALE,
-//      ProfileType.STUDENT,
-//      null
-//    );
-//
-//    // When
-//    Set<ConstraintViolation<DefaultProfilePatchRequest>> violations = validator.validate(
-//      requestWithBorderlineUsername);
-//
-//    // Then
-//    assertEquals(0, violations.size());
-//  }
-//
+package promiseofblood.umpabackend.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import promiseofblood.umpabackend.domain.entity.TeacherProfile;
+import promiseofblood.umpabackend.domain.entity.User;
+import promiseofblood.umpabackend.domain.repository.UserRepository;
+import promiseofblood.umpabackend.domain.vo.Gender;
+import promiseofblood.umpabackend.domain.vo.Major;
+import promiseofblood.umpabackend.domain.vo.ProfileType;
+import promiseofblood.umpabackend.domain.vo.Username;
+import promiseofblood.umpabackend.dto.TeacherProfileDto.TeacherProfileRequest;
+import promiseofblood.umpabackend.dto.UserDto.DefaultProfilePatchRequest;
+import promiseofblood.umpabackend.dto.UserDto.ProfileResponse;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private StorageService storageService;
+
+  @InjectMocks
+  private ProfileService subject;
+
+  private Validator validator;
+
+  @BeforeEach
+  void setUp() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @Test
+  @DisplayName("사용자 닉네임이 8자를 초과하면 검증 오류가 발생해야 한다")
+  void validateUsername_whenExceedsMaxLength_shouldFailValidation() {
+    // Given
+    DefaultProfilePatchRequest requestWithLongUsername = new DefaultProfilePatchRequest(
+      "닉네임이너무길어요", // 8자 초과 닉네임
+      Gender.MALE,
+      ProfileType.STUDENT,
+      null
+    );
+
+    // When
+    Set<ConstraintViolation<DefaultProfilePatchRequest>> violations = validator.validate(
+      requestWithLongUsername);
+
+    // Then
+    assertEquals(1, violations.size());
+    assertEquals("사용자 닉네임은 최대 8자까지 가능합니다.", violations.iterator().next().getMessage());
+  }
+
+  @Test
+  @DisplayName("사용자 닉네임이 8자 이하면 검증에 성공해야 한다")
+  void validateUsername_whenWithinMaxLength_shouldPassValidation() {
+    // Given
+    DefaultProfilePatchRequest requestWithValidUsername = new DefaultProfilePatchRequest(
+      "홍길동", // 8자 이하 닉네임
+      Gender.MALE,
+      ProfileType.STUDENT,
+      null
+    );
+
+    // When
+    Set<ConstraintViolation<DefaultProfilePatchRequest>> violations = validator.validate(
+      requestWithValidUsername);
+
+    // Then
+    assertEquals(0, violations.size());
+  }
+
+  @Test
+  @DisplayName("정확히 8자의 닉네임은 검증에 성공해야 한다")
+  void validateUsername_whenExactlyMaxLength_shouldPassValidation() {
+    // Given
+    DefaultProfilePatchRequest requestWithBorderlineUsername = new DefaultProfilePatchRequest(
+      "12345678", // 정확히 8자 닉네임
+      Gender.MALE,
+      ProfileType.STUDENT,
+      null
+    );
+
+    // When
+    Set<ConstraintViolation<DefaultProfilePatchRequest>> violations = validator.validate(
+      requestWithBorderlineUsername);
+
+    // Then
+    assertEquals(0, violations.size());
+  }
+
+  @Test
+  @DisplayName("대표 문구 수정 성공 테스트")
+  void patchTeacherProfile_whenOnlyUpdateKeyphrase() {
+    // Given
+    String newKeyphrase = "new_keyphrase";
+    final User user = createTestUser();
+    final TeacherProfileRequest teacherProfileRequest = TeacherProfileRequest.builder()
+      .keyphrase(newKeyphrase)
+      .build();
+
+    when(userRepository.findByLoginId(any())).thenReturn(Optional.of(user));
+    when(userRepository.save(any())).thenReturn(user);
+
+    // When
+    ProfileResponse profileResponseDto = subject.patchTeacherProfile(any(), teacherProfileRequest);
+
+    // Then
+    assertEquals(newKeyphrase, profileResponseDto.getTeacherProfile().getKeyphrase());
+  }
+
 //  @Test
 //  void patchDefaultProfile_whenUsernameIsInvalid() {
 //    // Given
@@ -128,4 +156,19 @@
 //      () -> subject.patchDefaultProfile(any(), defaultProfilePatchRequest)
 //    );
 //  }
-//}
+
+  private User createTestUser() {
+    final TeacherProfile teacherProfile = TeacherProfile.builder()
+      .keyphrase("keyphrase")
+      .careers(Collections.emptyList())
+      .links(Collections.emptyList())
+      .description("description")
+      .major(Major.BASS)
+      .build();
+    return User.builder()
+      .username(new Username("username"))
+      .profileType(ProfileType.STUDENT)
+      .teacherProfile(teacherProfile)
+      .build();
+  }
+}


### PR DESCRIPTION
## 주요 변경 사항
- 선생님 프로필에 대표문구(keyphrase) 항목 추가
- Service Detail 응답의 선생님 프로필에도 해당 항목 추가

## 기타
- 예상 리뷰 시간: 5~10분

`from` 함수 문제가 해결되면 올릴려 그랬는데 일단 올림...

@TGoddessana  develop 브랜치에 다시 PR 보냄... 졸다가 보냈나봐 암쏘 쏘리... 🙏