### PR TITLE
Fix: 선생님/학생 프로필 정보 순차적 입력(수정) 불가 해결

### DIFF
--- a/src/main/java/promiseofblood/umpabackend/application/service/ProfileService.java
+++ b/src/main/java/promiseofblood/umpabackend/application/service/ProfileService.java
@@ -51,10 +51,10 @@ public class ProfileService {
     TeacherProfile teacherProfile = user.getTeacherProfile();
 
     if (teacherProfile == null) {
-      teacherProfile = TeacherProfile.from(teacherProfileRequest);
-    } else {
-      teacherProfile.update(teacherProfileRequest);
+      teacherProfile = new TeacherProfile();
     }
+
+    teacherProfile.update(teacherProfileRequest);
 
     user.patchTeacherProfile(teacherProfile);
     User updatedUser = userRepository.save(user);
@@ -74,10 +74,10 @@ public class ProfileService {
     StudentProfile studentProfile = user.getStudentProfile();
 
     if (studentProfile == null) {
-      studentProfile = StudentProfile.from(studentProfileRequest);
-    } else {
-      studentProfile.update(studentProfileRequest);
+      studentProfile = new StudentProfile();
     }
+
+    studentProfile.update(studentProfileRequest);
 
     user.patchStudentProfile(studentProfile);
     User updatedUser = userRepository.save(user);

--- a/src/main/java/promiseofblood/umpabackend/domain/entity/StudentProfile.java
+++ b/src/main/java/promiseofblood/umpabackend/domain/entity/StudentProfile.java
@@ -20,9 +20,8 @@ import promiseofblood.umpabackend.dto.StudentProfileDto;
 
 @Entity
 @Getter
-@SuperBuilder
 @Table(name = "student_profiles")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class StudentProfile extends TimeStampedEntity {
 
   @Enumerated(EnumType.STRING)
@@ -37,14 +36,6 @@ public class StudentProfile extends TimeStampedEntity {
 
   @Enumerated(EnumType.STRING)
   private Grade grade;
-
-  public static StudentProfile from(StudentProfileDto.StudentProfileRequest request) {
-    return StudentProfile.builder()
-      .major(request.getMajor())
-      .preferredColleges(request.getPreferredColleges())
-      .grade(request.getGrade())
-      .build();
-  }
 
   public void update(StudentProfileDto.StudentProfileRequest request) {
     if (request.getMajor() != null) {

--- a/src/main/java/promiseofblood/umpabackend/domain/entity/TeacherProfile.java
+++ b/src/main/java/promiseofblood/umpabackend/domain/entity/TeacherProfile.java
@@ -18,10 +18,8 @@ import promiseofblood.umpabackend.dto.TeacherProfileDto;
 
 @Entity
 @Getter
-@Setter
-@SuperBuilder
 @Table(name = "teacher_profiles")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class TeacherProfile extends TimeStampedEntity {
 
   private String keyphrase;
@@ -36,17 +34,6 @@ public class TeacherProfile extends TimeStampedEntity {
 
   @OneToMany(mappedBy = "teacherProfile", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<TeacherLink> links;
-
-  public static TeacherProfile from(TeacherProfileDto.TeacherProfileRequest request) {
-
-    return TeacherProfile.builder()
-      .keyphrase(request.getKeyphrase())
-      .description(request.getDescription())
-      .major(request.getMajor())
-      .careers(request.getCareers().stream().map(TeacherCareer::from).toList())
-      .links(request.getLinks().stream().map(TeacherLink::from).toList())
-      .build();
-  }
 
   public boolean isProfileComplete() {
     return description != null && !description.isEmpty() &&

--- a/src/main/java/promiseofblood/umpabackend/dto/StudentProfileDto.java
+++ b/src/main/java/promiseofblood/umpabackend/dto/StudentProfileDto.java
@@ -3,6 +3,7 @@ package promiseofblood.umpabackend.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -44,15 +45,22 @@ public class StudentProfileDto {
 
     public static StudentProfileResponse from(StudentProfile studentProfile) {
 
-      List<ConstantDto.CollegeResponse> preferredColleges = new ArrayList<>();
-      for (College college : studentProfile.getPreferredColleges()) {
-        preferredColleges.add(ConstantDto.CollegeResponse.from(college));
+      List<ConstantDto.CollegeResponse> preferredCollegeDtoList = new ArrayList<>();
+      List<College> preferredColleges = studentProfile.getPreferredColleges();
+      if (preferredColleges != null) {
+        for (College college : preferredColleges) {
+          preferredCollegeDtoList.add(ConstantDto.CollegeResponse.from(college));
+        }
       }
 
       return StudentProfileResponse.builder()
-          .major(MajorResponse.from(studentProfile.getMajor()))
-          .preferredColleges(preferredColleges)
-          .grade(ConstantDto.GradeResponse.from(studentProfile.getGrade()))
+          .major(Optional.ofNullable(studentProfile.getMajor())
+            .map(MajorResponse::from)
+            .orElse(null))
+          .preferredColleges(preferredCollegeDtoList)
+          .grade(Optional.ofNullable(studentProfile.getGrade())
+            .map(ConstantDto.GradeResponse::from)
+            .orElse(null))
           .build();
     }
   }

--- a/src/main/java/promiseofblood/umpabackend/dto/TeacherProfileDto.java
+++ b/src/main/java/promiseofblood/umpabackend/dto/TeacherProfileDto.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +16,7 @@ import promiseofblood.umpabackend.domain.entity.TeacherCareer;
 import promiseofblood.umpabackend.domain.entity.TeacherLink;
 import promiseofblood.umpabackend.domain.entity.TeacherProfile;
 import promiseofblood.umpabackend.domain.vo.Major;
-import promiseofblood.umpabackend.domain.vo.Region;
+import promiseofblood.umpabackend.dto.ConstantDto.MajorResponse;
 
 public class TeacherProfileDto {
 
@@ -84,19 +85,27 @@ public class TeacherProfileDto {
     public static TeacherProfileResponse from(TeacherProfile teacherProfile) {
 
       List<TeacherCareerDto> teacherCareerDtoList = new ArrayList<>();
-      for (TeacherCareer teacherCareer : teacherProfile.getCareers()) {
-        teacherCareerDtoList.add(TeacherCareerDto.from(teacherCareer));
+      List<TeacherCareer> teacherCareers = teacherProfile.getCareers();
+      if (teacherCareers != null) {
+        for (TeacherCareer teacherCareer : teacherCareers) {
+          teacherCareerDtoList.add(TeacherCareerDto.from(teacherCareer));
+        }
       }
 
       List<TeacherLinkDto> teacherLinkDtoList = new ArrayList<>();
-      for (TeacherLink teacherLink : teacherProfile.getLinks()) {
-        teacherLinkDtoList.add(TeacherLinkDto.from(teacherLink));
+      List<TeacherLink> teacherLinks = teacherProfile.getLinks();
+      if (teacherLinks != null) {
+        for (TeacherLink teacherLink : teacherLinks) {
+          teacherLinkDtoList.add(TeacherLinkDto.from(teacherLink));
+        }
       }
 
       return TeacherProfileResponse.builder()
           .keyphrase(teacherProfile.getKeyphrase())
           .description(teacherProfile.getDescription())
-          .major(ConstantDto.MajorResponse.from(teacherProfile.getMajor()))
+          .major(Optional.ofNullable(teacherProfile.getMajor())
+            .map(MajorResponse::from)
+            .orElse(null))
           .careers(teacherCareerDtoList)
           .links(teacherLinkDtoList)
           .build();


### PR DESCRIPTION
## 주요 변경 사항
- 처음 회원가입 과정 중 순차적으로 학생/선생님 프로필 정보 입력 시 발생하는 오류 수정
  - 원인: null 값에 `.stream()` 함수 등 호출로 인한 Exception 발생
- 사용처가 한정된 `from` 함수 제거
  - 오직 처음 회원가입 시 학생/선생님 프로필 정보 객체를 만들기 위해 사용되었음

## 기타
- 예상 리뷰 시간: 10~15분

⚡️ 예상 리뷰 시간이 얼마나 정확했는지 0~5점까지 코멘트로 남겨주시면 앞으로 더욱 정확한 예상 시간을 표기해 드립미다...