### PR TITLE
Fix: 닉네임 중복 확인 API 오류 해결

### DIFF
--- a/src/main/java/promiseofblood/umpabackend/application/service/UserService.java
+++ b/src/main/java/promiseofblood/umpabackend/application/service/UserService.java
@@ -14,6 +14,7 @@ import promiseofblood.umpabackend.domain.entity.User;
 import promiseofblood.umpabackend.domain.repository.UserRepository;
 import promiseofblood.umpabackend.domain.vo.Role;
 import promiseofblood.umpabackend.domain.vo.UserStatus;
+import promiseofblood.umpabackend.domain.vo.Username;
 import promiseofblood.umpabackend.dto.LoginDto;
 import promiseofblood.umpabackend.dto.LoginDto.LoginCompleteResponse;
 import promiseofblood.umpabackend.web.schema.request.RegisterByLoginIdPasswordRequest;
@@ -124,17 +125,19 @@ public class UserService {
     return LoginCompleteResponse.of(RetrieveFullProfileResponse.from(user), jwtPairResponse);
   }
 
-  public CheckIsUsernameAvailableResponse isUsernameAvailable(String username) {
-    if (!isUsernamePatternValid(username)) {
+  public CheckIsUsernameAvailableResponse isUsernameAvailable(String rawUsername) {
+    if (!isUsernamePatternValid(rawUsername)) {
       return new CheckIsUsernameAvailableResponse(
-          username, false, "아이디는 한글, 영문, 숫자만 사용 가능하며 최대 8글자입니다.");
+          rawUsername, false, "아이디는 한글, 영문, 숫자만 사용 가능하며 최대 8글자입니다.");
     }
+
+    Username username = new Username(rawUsername);
 
     if (!isUsernameDuplicated(username)) {
-      return new CheckIsUsernameAvailableResponse(username, false, "이미 사용 중인 아이디입니다.");
+      return new CheckIsUsernameAvailableResponse(rawUsername, false, "이미 사용 중인 아이디입니다.");
     }
 
-    return new CheckIsUsernameAvailableResponse(username, true, "사용 가능한 아이디입니다.");
+    return new CheckIsUsernameAvailableResponse(rawUsername, true, "사용 가능한 아이디입니다.");
   }
 
   public boolean isUsernamePatternValid(String username) {
@@ -143,7 +146,7 @@ public class UserService {
     return username != null && username.matches(regex);
   }
 
-  public boolean isUsernameDuplicated(String username) {
+  public boolean isUsernameDuplicated(Username username) {
 
     return !userRepository.existsByUsername(username);
   }

--- a/src/main/java/promiseofblood/umpabackend/domain/repository/UserRepository.java
+++ b/src/main/java/promiseofblood/umpabackend/domain/repository/UserRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import promiseofblood.umpabackend.domain.entity.User;
+import promiseofblood.umpabackend.domain.vo.Username;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -12,7 +13,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   boolean existsByLoginId(String loginId);
 
-  boolean existsByUsername(String username);
+  boolean existsByUsername(Username username);
 
   Optional<User> findByOauth2User_ProviderNameAndOauth2User_ProviderUid(
       String providerName, String providerUid);

--- a/src/test/java/promiseofblood/umpabackend/application/service/UserServiceTest.java
+++ b/src/test/java/promiseofblood/umpabackend/application/service/UserServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import promiseofblood.umpabackend.domain.repository.UserRepository;
+import promiseofblood.umpabackend.domain.vo.Username;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -22,7 +23,7 @@ class UserServiceTest {
   @Test
   @DisplayName("isUsernameDuplicated 메서드는 닉네임이 중복되었을 경우 false를 반환한다.")
   void isUsernameDuplicated_UsernameExists_ReturnsTrue() {
-    String username = "existing-user";
+    Username username = new Username("existing");
     when(userRepository.existsByUsername(username)).thenReturn(true);
 
     boolean isAvailable = userService.isUsernameDuplicated(username);
@@ -33,7 +34,7 @@ class UserServiceTest {
   @Test
   @DisplayName("isUsernameDuplicated 메서드는 닉네임이 중복되지 않았을 경우 true를 반환한다.")
   void isUsernameDuplicated_UsernameDoesNotExist_ReturnsFalse() {
-    String username = "new-user";
+    Username username = new Username("new");
     when(userRepository.existsByUsername(username)).thenReturn(false);
 
     boolean isAvailable = userService.isUsernameDuplicated(username);

--- a/src/test/java/promiseofblood/umpabackend/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/promiseofblood/umpabackend/domain/repository/UserRepositoryTest.java
@@ -1,0 +1,39 @@
+package promiseofblood.umpabackend.domain.repository;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import promiseofblood.umpabackend.domain.entity.User;
+import promiseofblood.umpabackend.domain.vo.Role;
+import promiseofblood.umpabackend.domain.vo.UserStatus;
+import promiseofblood.umpabackend.domain.vo.Username;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class UserRepositoryTest {
+
+  @Autowired private UserRepository subject;
+
+  @Test
+  void existsByUsername() {
+    // Given
+    Username username = new Username("test");
+    User user =
+        User.builder()
+            .loginId("loginId")
+            .role(Role.USER)
+            .userStatus(UserStatus.ACTIVE)
+            .username(username)
+            .build();
+
+    subject.save(user);
+
+    // When
+    boolean isUsernameExisted = subject.existsByUsername(username);
+
+    // Then
+    Assertions.assertTrue(isUsernameExisted);
+  }
+}


### PR DESCRIPTION
## 주요 변경 사항
- 닉네임 중복 확인 API `/api/v1/users/register/check/username` 호출 시 500에러 해결
  - Repository 함수 파라미터 수정
- Repository 관련 unit test 추가

## 기타
- 예상 리뷰 시간: 3~5분

⚡️ 예상 리뷰 시간이 얼마나 정확했는지 0~5점까지 코멘트로 남겨주시면 앞으로 더욱 정확한 예상 시간을 표기해 드립미다...

